### PR TITLE
Fixed velocities not being set to zero when stale

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -278,7 +278,7 @@ void ServoCalcs::run(const ros::TimerEvent& timer_event)
   {
     // Joint trajectory is not populated with anything, so set it to the last positions and 0 velocity
     *joint_trajectory = *last_sent_command_;
-    for (auto point : joint_trajectory->points)
+    for (auto& point : joint_trajectory->points)
     {
       point.velocities.assign(point.velocities.size(), 0);
     }


### PR DESCRIPTION
### Description
Changed the range-based for loop in `serve_calcs.cpp` to pass-by-reference such that velocities really are set to zero when stale.

I hope I am doing the pull request procedure correctly as this is my first time opening a pull request to a larger project. Please feel free to correct me!

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
